### PR TITLE
Adding an external api type for external requests

### DIFF
--- a/src/exchange/connection.py
+++ b/src/exchange/connection.py
@@ -54,6 +54,7 @@ class Connection:
             headers={
                 "accept": "application/json",
                 "content-type": "application/json",
+                "Authorization": self._auth.get_authorization_header(),
             },
         )
         resp.raise_for_status()

--- a/src/exchange/connection.py
+++ b/src/exchange/connection.py
@@ -1,11 +1,12 @@
 from enum import Enum
-from typing import Dict, Optional, Union
+from typing import Optional, Union
 
 import requests  # type:ignore
 from fastapi.testclient import TestClient
 from requests import Session
 
 from src.helpers.constants import LOGIN_URL
+from src.helpers.types.api import ExternalApi
 from src.helpers.types.auth import Auth, LogInRequest, LogInResponse
 from src.helpers.types.url import URL
 
@@ -36,7 +37,7 @@ class Connection:
         self,
         method: Method,
         url: URL,
-        body: Optional[Dict[str, str]] = None,
+        body: Optional[ExternalApi] = None,
         check_auth: bool = True,
         **kwargs
     ):
@@ -62,7 +63,7 @@ class Connection:
     def get(self, url: URL, **kwargs):
         return self._request(Method.GET, url, **kwargs)
 
-    def post(self, url: URL, body: Optional[Dict[str, str]] = None, **kwargs):
+    def post(self, url: URL, body: Optional[ExternalApi] = None, **kwargs):
         return self._request(Method.POST, url, body=body, **kwargs)
 
     def sign_in(self):

--- a/src/helpers/types/api.py
+++ b/src/helpers/types/api.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class ExternalApi(BaseModel):
+    """This class is a type for api requests and responses"""

--- a/src/helpers/types/auth.py
+++ b/src/helpers/types/auth.py
@@ -3,8 +3,6 @@ import typing
 from datetime import datetime, timedelta
 from typing import Optional
 
-from pydantic import BaseModel
-
 from src.helpers.constants import (
     API_VERSION_ENV_VAR,
     ENV_VARS,
@@ -13,6 +11,7 @@ from src.helpers.constants import (
     URL_ENV_VAR,
     USERNAME_ENV_VAR,
 )
+from src.helpers.types.api import ExternalApi
 from src.helpers.types.url import URL
 
 
@@ -32,12 +31,12 @@ class Username(str):
     """Type that encapsulates username"""
 
 
-class LogInResponse(BaseModel):
+class LogInResponse(ExternalApi):
     member_id: MemberId
     token: Token
 
 
-class LogInRequest(BaseModel):
+class LogInRequest(ExternalApi):
     email: Username
     password: Password
 

--- a/src/helpers/types/auth.py
+++ b/src/helpers/types/auth.py
@@ -77,3 +77,8 @@ class Auth:
         self._member_id = login_response.member_id
         self._token = login_response.token
         self._sign_in_time = datetime.now()
+
+    def get_authorization_header(self) -> str:
+        if self._member_id is None or self._token is None:
+            raise ValueError("The member id and the token must be filled out!")
+        return str(self._member_id) + " " + str(self._token)


### PR DESCRIPTION
This pr creates an external class so that we can make sure that only external api types are sent to the exchange.